### PR TITLE
Mudanças em Personagem e Arena

### DIFF
--- a/lib/arena.rb
+++ b/lib/arena.rb
@@ -13,24 +13,26 @@ class Arena
 		(distancia(personagem_1,personagem_2) < maior_distancia)
 	end
 
-	def distancia(personagem_1,personagem_2)
+	def distancia(personagem_1, personagem_2)
 		a = (personagem_1.x - personagem_2.x)**2
 		b = (personagem_1.y - personagem_2.y)**2
 		Math.sqrt(a+b)
 	end
 
 	def add_personagem(personagem, x, y)
-		personagens.append(personagem)
+		@personagens.push(personagem)
 		personagem.x = x
 		personagem.y = y
+		personagem.arena = self
 	end
 
 	def dentro_arena?(x, y)
-		x.between? 1, @width and y.between? 1, @height
+		x.between? 1, @width and y.between? 1, @height	
 	end
 
 	def na_arena?(personagem)
-		self.dentro_arena? personagem.x, personagem.y
+		nos_limites = self.dentro_arena? personagem.x, personagem.y
+		@personagens.include?(personagem) && nos_limites
 	end
 
 	def mover(personagem, x, y)
@@ -42,5 +44,23 @@ class Arena
 
 		false
 	end
+ 
+	def pode_atacar(atacante, atacado)
+		distancia = self.distancia(atacante, atacado)		
+		if atacante.arma.distancia >= distancia then 
+			return true
+		end	
+		false
+	end
 
+	def atacar(atacante, atacado)
+		if atacante.arma == nil then
+		 raise "atacante necessita de uma arma"
+		end
+ 
+		if  self.pode_atacar(atacante, atacado) then
+			atacado.hp -= atacante.arma.dano
+		end
+	end
 end
+ 

--- a/lib/personagem.rb
+++ b/lib/personagem.rb
@@ -1,13 +1,20 @@
 class Personagem
-	attr_accessor :nome, :arma, :hp, :x, :y
-	def initialize(nome, arma, hp, x, y)
+	attr_accessor :nome, :arma, :hp, :x, :y, :arena
+	def initialize(nome, arma, hp)
 		@nome = nome
 		@arma = arma
 		@hp = hp
-		@x = x
-		@y = y
+		@x = 0
+		@y = 0
 	end
 
 	def atacar(personagem)
+		 self.arena.atacar(self, personagem)
 	end
+
+
+	def esta_vivo 
+		hp > 0
+	end
+
 end

--- a/spec/lib/test_spec.rb
+++ b/spec/lib/test_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "spec_helper"
 require "arena"
 require "personagem"
@@ -10,6 +11,7 @@ describe "Combate arena" do
 		@arma_espada = Arma.new('Espada', 1, 20)
 		@arma_lanca = Arma.new('Lança', 3, 15)
 		@arma_flecha = Arma.new('Flecha', 5, 10)
+		@arma_galho = Arma.new('Galho', 1, 1)
 	end
 
 	it "Criar a arena 20x20" do
@@ -33,58 +35,120 @@ describe "Combate arena" do
 	end
 
 	it "Criar personagens" do
-		personagem = Personagem.new('Leonidas', @arma_espada, 200, 3, 2)
+		personagem = Personagem.new('Leonidas', @arma_espada, 200)
 
 		expect(personagem.nome).to eq('Leonidas')
 		expect(personagem.arma).to eq(@arma_espada)
 		expect(personagem.hp).to eq(200)
-		expect(personagem.x).to eq(3)
-		expect(personagem.y).to eq(2)
+		
 	end
 
-	it "Se estão em combate" do
-		personagem1 = Personagem.new('Leonidas', @arma_espada, 200, 4, 6)
-		personagem2 = Personagem.new('Hulk', @arma_lanca, 800, 5, 7)
+
+	it "Se estao em combate" do
+		personagem1 = Personagem.new('Leonidas', @arma_espada, 200)
+		personagem2 = Personagem.new('Hulk', @arma_lanca, 800)
+
+		@arena.add_personagem(personagem1, 4, 6)
+		@arena.add_personagem(personagem2, 5, 7)
+
 
 		arena_combate = @arena.em_combate?(personagem1, personagem2)
 
 		expect(arena_combate).to be_truthy
 	end
 
-	it "Se não estão em combate" do
-		personagem1 = Personagem.new('Leonidas', @arma_espada, 200, 8, 8)
-		personagem2 = Personagem.new('Hulk', @arma_lanca, 800, 5, 7)
+
+	it "Se nao estao em combate" do
+		
+		personagem1 = Personagem.new('Leonidas', @arma_espada, 200)
+		personagem2 = Personagem.new('Hulk', @arma_lanca, 800)
+
+		@arena.add_personagem(personagem1, 8, 8)
+		@arena.add_personagem(personagem2, 5, 7)
 
 		arena_combate = @arena.em_combate?(personagem1, personagem2)
-
+		
 		expect(arena_combate).to be_falsey
 	end
 
+
+	it "Se pode atacar" do 
+
+		personagem1 = Personagem.new('Leonidas', @arma_espada, 200)
+		personagem2 = Personagem.new('Hulk', @arma_flecha, 800)
+
+		@arena.add_personagem(personagem1, 7, 8)
+		@arena.add_personagem(personagem2, 5, 7)
+
+
+		#espada sem distancia para atacar
+		expect(@arena.pode_atacar(personagem1, personagem2)).to be_falsey
+		#arco com distancia pra atacar
+		expect(@arena.pode_atacar(personagem2, personagem1)).to be_truthy
+
+	end
+
+	it "Deve atacar personagem" do 
+
+		personagem1 = Personagem.new('Leonidas', @arma_flecha, 200)
+		personagem2 = Personagem.new('Hulk', @arma_lanca, 800)
+
+		@arena.add_personagem(personagem1, 8, 8)
+		@arena.add_personagem(personagem2, 5, 7)
+		
+		personagem1.atacar(personagem2)
+		expect(personagem2.hp).to eq(790)
+	end
+
+
 	it "Se estão dentro da arena" do
-		personagem = Personagem.new('Leonidas', @arma_espada, 200, 8, 8)
+		personagem = Personagem.new('Leonidas', @arma_espada, 200)
+		@arena.add_personagem(personagem, 8, 8)
 		na_arena = @arena.na_arena?(personagem)
 
 		expect(na_arena).to be_truthy
 	end
 
 	it "Se estão fora da arena" do
-		personagem = Personagem.new('Leonidas', @arma_espada, 200, 20, 21)
+		personagem = Personagem.new('Leonidas', @arma_espada, 200)
 		na_arena = @arena.na_arena?(personagem)
 
 		expect(na_arena).to be_falsey
 	end
 
 	it "Efetuar movimento válido" do
-		personagem = Personagem.new('Leonidas', @arma_espada, 200, 8, 8)
+		personagem = Personagem.new('Leonidas', @arma_espada, 200)
 
+		@arena.add_personagem(personagem , 8, 8)
+		
 		moveu = @arena.mover(personagem, 6, 7)
 		expect(moveu).to be_truthy
 		expect(personagem.x).to eq(6)
 		expect(personagem.y).to eq(7)
 	end
 
+	it "Apos ataque maior ou igual a vida, deve morrer" do
+
+		personagem1 = Personagem.new('Leonidas', @arma_espada, 200)
+		personagem2 = Personagem.new('João Bobo', @arma_galho, 30)
+
+		@arena.add_personagem(personagem1, 5, 8)
+		@arena.add_personagem(personagem2, 5, 7)
+		
+		#primeiro ataque não mata
+		personagem1.atacar(personagem2)
+		expect(personagem2.esta_vivo).to be_truthy
+
+		#segundo ataque mata
+		personagem1.atacar(personagem2)
+		expect(personagem2.esta_vivo).to be_falsey
+
+	end
+
+
 	it "Efetuar movimento inválido" do
-		personagem = Personagem.new('Leonidas', @arma_espada, 200, 8, 8)
+		personagem = Personagem.new('Leonidas', @arma_espada, 200)
+		@arena.add_personagem(personagem , 8, 8)
 
 		moveu = @arena.mover(personagem, 21, 3)
 		expect(moveu).to be_falsey
@@ -93,3 +157,4 @@ describe "Combate arena" do
 	end
 
 end
+


### PR DESCRIPTION
Removida a responsabilidade de iniciar com posição do Personagem,
atribuida a Arena
Atribudo a Arena a responsabilidade de gerenciar ataques à arena
Incluido uma verificação junto ao metodo "estar na arena" da arena,
possibilitando apenas personagens
que  foram inseridos na arena

criado testes para os itens acima
